### PR TITLE
마인크래프트 DB 연동 및 게임 내 유저 정보조회 구현 완료

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/gradlew text eol=lf
+*.bat text eol=crlf
+*.jar binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Application Yaml ###
+**/src/main/resources/application**.yaml
+
+### redis & mysql ###
+/storage
+
+### static ###
+/src/main/resources/static

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// swagger ui
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 
 	// OAuth
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/build.gradle
+++ b/build.gradle
@@ -24,16 +24,50 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'io.projectreactor:reactor-test'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testImplementation 'com.squareup.okhttp3:mockwebserver'
+
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+	// swagger ui
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// OAuth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok:1.18.20'
+	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+	// spring data jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// h2
+	runtimeOnly 'com.h2database:h2'
+
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/turtle/minecraft_service/config/HttpErrorCode.java
+++ b/src/main/java/org/turtle/minecraft_service/config/HttpErrorCode.java
@@ -1,0 +1,110 @@
+package org.turtle.minecraft_service.config;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HttpErrorCode {
+    // ----- Common ------
+    NotValidRequestError(
+            HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."
+    ),
+    QueryParamTypeMismatchError(
+            HttpStatus.BAD_REQUEST, "쿼리 파라미터의 타입이 올바르지 않습니다."
+    ),
+    MissingQueryParamError(
+            HttpStatus.BAD_REQUEST, "파라미터의 값이 존재하지 않습니다."
+    ),
+    MissingRequestHeaderError(
+            HttpStatus.BAD_REQUEST, "헤더의 값이 존재하지 않습니다."
+    ),
+    AccessDeniedError(
+            HttpStatus.FORBIDDEN, "접근할 수 없는 권한을 가진 사용자입니다."
+    ),
+    InternalServerError(
+            HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생하였습니다. 문제가 지속되면 관리자에게 문의하세요."
+    ),
+
+    // ----- User ------
+    DuplicatedNicknameError(
+            HttpStatus.CONFLICT, "중복된 닉네임입니다"
+    ),
+    UserNotFoundError(
+            HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."
+    ),
+    UserPermissionDeniedError(
+            HttpStatus.FORBIDDEN, "권한이 없는 유저입니다."
+    ),
+    AlreadyExistUserError(
+            HttpStatus.CONFLICT, "이미 존재하는 유저입니다."
+    ),
+
+    // ----- OAuth ------
+    UnauthorizedKakaoError(
+            HttpStatus.UNAUTHORIZED, "카카오를 통한 인증에 실패하였습니다."
+    ),
+
+    ForbiddenKakaoError(
+            HttpStatus.FORBIDDEN, "허가되지 않은 카카오 접근입니다."
+    ),
+    UnauthorizedNaverError(
+            HttpStatus.UNAUTHORIZED, "네이버를 통한 인증에 실패하였습니다."
+    ),
+
+    ForbiddenNaverError(
+            HttpStatus.FORBIDDEN, "허가되지 않은 네이버 접근입니다."
+    ),
+
+    // ----- Token ------
+    NotValidTokenError(
+            HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."
+    ),
+    NotValidAccessTokenError(
+            HttpStatus.UNAUTHORIZED, "유효하지 않은 AccessToken입니다."
+    ),
+    NotExpiredAccessTokenError(
+            HttpStatus.UNAUTHORIZED, "만료되지 않은 AccessToken입니다."
+    ),
+    ExpiredAccessTokenError(
+            HttpStatus.UNAUTHORIZED, "만료된 AccessToken입니다."
+    ),
+    NoSuchAccessTokenError(
+            HttpStatus.UNAUTHORIZED, "존재하지 않은 AccessToken입니다."
+    ),
+    NotValidRefreshTokenError(
+            HttpStatus.UNAUTHORIZED, "유효하지 않은 RefreshToken입니다."
+    ),
+    NotExpiredRefreshTokenError(
+            HttpStatus.UNAUTHORIZED, "만료되지 않은 RefreshToken입니다."
+    ),
+    ExpiredRefreshTokenError(
+            HttpStatus.UNAUTHORIZED, "만료된 RefreshToken입니다."
+    ),
+    NoSuchRefreshTokenError(
+            HttpStatus.UNAUTHORIZED, "존재하지 않은 RefreshToken입니다."
+    ),
+    // ----- Survey ------
+    NoSuchSurveyError(
+            HttpStatus.NOT_FOUND, "존재하지 않은 설문조사입니다."
+    ),
+    NoSuchSurveySatisfiedError(
+            HttpStatus.NOT_FOUND, "존재하지 않은 설문 만족도입니다."
+    ),
+    // ----- Policy ------
+    PolicyNotFoundError(
+            HttpStatus.NOT_FOUND, "존재하지 않는 정책입니다."
+    ),
+
+    // ----- Suggestion ------
+    SuggestionNotFoundError(
+            HttpStatus.NOT_FOUND, "존재하지 않는 제안 정책입니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    HttpErrorCode(HttpStatus httpStatus, String message){
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/config/HttpErrorCode.java
+++ b/src/main/java/org/turtle/minecraft_service/config/HttpErrorCode.java
@@ -38,6 +38,9 @@ public enum HttpErrorCode {
     AlreadyExistUserError(
             HttpStatus.CONFLICT, "이미 존재하는 유저입니다."
     ),
+    AlreadyExistNicknameError(
+            HttpStatus.CONFLICT, "해당 닉네임으로 생성된 계정이 존재합니다."
+    ),
 
     // ----- OAuth ------
     UnauthorizedKakaoError(
@@ -53,6 +56,14 @@ public enum HttpErrorCode {
 
     ForbiddenNaverError(
             HttpStatus.FORBIDDEN, "허가되지 않은 네이버 접근입니다."
+    ),
+
+    UnauthorizedGoogleError(
+            HttpStatus.UNAUTHORIZED, "구글을 통한 인증에 실패하였습니다."
+    ),
+
+    ForbiddenGoogleError(
+            HttpStatus.FORBIDDEN, "허가되지 않은 구글 접근입니다."
     ),
 
     // ----- Token ------
@@ -82,22 +93,6 @@ public enum HttpErrorCode {
     ),
     NoSuchRefreshTokenError(
             HttpStatus.UNAUTHORIZED, "존재하지 않은 RefreshToken입니다."
-    ),
-    // ----- Survey ------
-    NoSuchSurveyError(
-            HttpStatus.NOT_FOUND, "존재하지 않은 설문조사입니다."
-    ),
-    NoSuchSurveySatisfiedError(
-            HttpStatus.NOT_FOUND, "존재하지 않은 설문 만족도입니다."
-    ),
-    // ----- Policy ------
-    PolicyNotFoundError(
-            HttpStatus.NOT_FOUND, "존재하지 않는 정책입니다."
-    ),
-
-    // ----- Suggestion ------
-    SuggestionNotFoundError(
-            HttpStatus.NOT_FOUND, "존재하지 않는 제안 정책입니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/turtle/minecraft_service/config/JpaAuditorConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/JpaAuditorConfig.java
@@ -1,0 +1,9 @@
+package org.turtle.minecraft_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditorConfig {
+}

--- a/src/main/java/org/turtle/minecraft_service/config/PrimaryDBConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/PrimaryDBConfig.java
@@ -1,0 +1,60 @@
+package org.turtle.minecraft_service.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "org.turtle.minecraft_service.repository.primary",
+        entityManagerFactoryRef = "primaryEntityManager",
+        transactionManagerRef = "primaryTransactionManager"
+)
+public class PrimaryDBConfig {
+
+    @Bean
+    @Primary
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource primaryDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    @Primary
+    public LocalContainerEntityManagerFactoryBean primaryEntityManager() {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(primaryDataSource());
+        em.setPackagesToScan(new String[] {"org.turtle.minecraft_service.domain.primary"});
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setShowSql(true);
+        vendorAdapter.setGenerateDdl(true);
+        em.setJpaVendorAdapter(vendorAdapter);
+
+        HashMap<String, Object> prop = new HashMap<>();
+        prop.put("hibernate.dialect", "org.hibernate.dialect.MySQLDialect");
+        prop.put("hibernate.hbm2ddl.auto", "update");
+        prop.put("hibernate.format_sql", true);
+        em.setJpaPropertyMap(prop);
+
+        return em;
+    }
+
+    @Primary
+    @Bean
+    public PlatformTransactionManager primaryTransactionManager() {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(primaryEntityManager().getObject());
+        return transactionManager;
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/config/RedisConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package org.turtle.minecraft_service.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate redisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/config/SecondaryDBConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/SecondaryDBConfig.java
@@ -1,0 +1,56 @@
+package org.turtle.minecraft_service.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@EnableJpaRepositories(
+        basePackages = "org.turtle.minecraft_service.repository.secondary",
+        entityManagerFactoryRef = "secondaryEntityManager",
+        transactionManagerRef = "secondaryTransactionManager"
+)
+@Configuration
+public class SecondaryDBConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.second-datasource")
+    public DataSource secondaryDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean secondaryEntityManager() {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(secondaryDataSource());
+        em.setPackagesToScan(new String[] {"org.turtle.minecraft_service.domain.secondary"});
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setShowSql(true);
+        vendorAdapter.setGenerateDdl(true);
+        em.setJpaVendorAdapter(vendorAdapter);
+
+        HashMap<String, Object> prop = new HashMap<>();
+        prop.put("hibernate.dialect", "org.hibernate.dialect.MySQLDialect");
+        prop.put("hibernate.hbm2ddl.auto", "update");
+        prop.put("hibernate.format_sql", true);
+        em.setJpaPropertyMap(prop);
+
+        return em;
+    }
+
+    @Bean
+    public PlatformTransactionManager secondaryTransactionManager() {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(secondaryEntityManager().getObject());
+        return transactionManager;
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/config/SecurityConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/SecurityConfig.java
@@ -1,11 +1,63 @@
 package org.turtle.minecraft_service.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.turtle.minecraft_service.filter.JwtAuthenticationFilter;
+import org.turtle.minecraft_service.provider.JwtTokenProvider;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers((headerConfig) ->
+                        headerConfig.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable
+                        )
+                )
+                .sessionManagement(httpSecuritySessionManagementConfigurer ->
+                        httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/h2-console/**", "/images/**", "/swagger-ui/**", "/v3/**").permitAll() // 모든 사용자에게 접근 허용
+                                .anyRequest().authenticated() // 이외의 Url에 대해서는 403 에러 발생
+                )
+                .addFilterAfter(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer(){
+        return web -> web.ignoring().requestMatchers( // 해당 URL에 대해서는 Spring SecurityFilter 적용 안됨
+                "/api/auth/login",
+                "/api/auth/check/nickname",
+                "/api/auth/logout",
+                "/api/auth/refreshToken",
+                "/api/auth/signup",
+                "/h2-console/**",
+                "/images/**",
+                "/swagger-ui/**",
+                "/v3/**");
+
+    }
 }

--- a/src/main/java/org/turtle/minecraft_service/config/SecurityConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/SecurityConfig.java
@@ -1,0 +1,11 @@
+package org.turtle.minecraft_service.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+}

--- a/src/main/java/org/turtle/minecraft_service/config/SwaggerConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/SwaggerConfig.java
@@ -1,0 +1,122 @@
+package org.turtle.minecraft_service.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import org.turtle.minecraft_service.exception.ErrorResponseDto;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExample;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExamples;
+import org.turtle.minecraft_service.swagger.ExampleHolder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Study Sync API 문서") // API의 제목
+                .description("Study Sync API 명세서입니다.") // API에 대한 설명
+                .version("1.0.0"); // API의 버전
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(
+                    ApiErrorCodeExamples.class);
+
+            // @ApiErrorCodeExamples 어노테이션이 붙어있다면
+            if (apiErrorCodeExamples != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExamples.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ApiErrorCodeExample[] apiErrorCodeExamples) {
+        ApiResponses responses = operation.getResponses();
+
+        // ExampleHolder(에러 응답값) 객체를 만들고 에러 코드별로 그룹화
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(apiErrorCodeExamples)
+                .map(apiErrorCodeExample -> ExampleHolder.builder()
+                        .holder(getSwaggerExample(apiErrorCodeExample.value(), apiErrorCodeExample.description()))
+                        .code(apiErrorCodeExample.value().getHttpStatus().value())
+                        .name(apiErrorCodeExample.value().name())
+                        .build()
+                )
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        // ExampleHolders를 ApiResponses에 추가
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+
+
+    // ErrorResponseDto 형태의 예시 객체 생성
+    private Example getSwaggerExample(HttpErrorCode errorCode, String description) {
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.from(errorCode);
+        Example example = new Example();
+        example.setValue(errorResponseDto);
+        if(!description.isEmpty()) {
+            example.setDescription(description);
+        }
+
+        return example;
+    }
+
+    // exampleHolder를 ApiResponses에 추가
+    private void addExamplesToResponses(ApiResponses responses,
+                                        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(),
+                                    exampleHolder.getHolder()
+                            )
+                    );
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(String.valueOf(status), apiResponse);
+                }
+        );
+    }
+}
+

--- a/src/main/java/org/turtle/minecraft_service/config/SwaggerConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/SwaggerConfig.java
@@ -46,8 +46,8 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("Study Sync API 문서") // API의 제목
-                .description("Study Sync API 명세서입니다.") // API에 대한 설명
+                .title("거북이 놀이터 API 문서") // API의 제목
+                .description("거북이 놀이터 API 명세서입니다.") // API에 대한 설명
                 .version("1.0.0"); // API의 버전
     }
 

--- a/src/main/java/org/turtle/minecraft_service/config/WebClientConfig.java
+++ b/src/main/java/org/turtle/minecraft_service/config/WebClientConfig.java
@@ -1,0 +1,31 @@
+package org.turtle.minecraft_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.turtle.minecraft_service.constant.SnsBaseUrl;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient googleWebClient(){
+        return WebClient.builder()
+                .baseUrl(SnsBaseUrl.GoogleBaseUrl.getUrl())
+                .build();
+    }
+
+    @Bean
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+                .baseUrl(SnsBaseUrl.KakaoBaseUrl.getUrl())
+                .build();
+    }
+
+    @Bean
+    public WebClient naverWebClient(){
+        return WebClient.builder()
+                .baseUrl(SnsBaseUrl.NaverBaseUrl.getUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/constant/SnsBaseUrl.java
+++ b/src/main/java/org/turtle/minecraft_service/constant/SnsBaseUrl.java
@@ -1,0 +1,15 @@
+package org.turtle.minecraft_service.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SnsBaseUrl {
+    GoogleBaseUrl("https://www.googleapis.com"),
+    KakaoBaseUrl("https://kapi.kakao.com"),
+    NaverBaseUrl("https://openapi.naver.com"),
+    TestBaseUrl("http://localhost");
+
+    private final String url;
+}

--- a/src/main/java/org/turtle/minecraft_service/constant/SnsType.java
+++ b/src/main/java/org/turtle/minecraft_service/constant/SnsType.java
@@ -1,0 +1,6 @@
+package org.turtle.minecraft_service.constant;
+
+public enum SnsType {
+
+    Google, Naver, Kakao
+}

--- a/src/main/java/org/turtle/minecraft_service/constant/TokenType.java
+++ b/src/main/java/org/turtle/minecraft_service/constant/TokenType.java
@@ -1,0 +1,5 @@
+package org.turtle.minecraft_service.constant;
+
+public enum TokenType {
+    ACCESS_TOKEN, REFRESH_TOKEN
+}

--- a/src/main/java/org/turtle/minecraft_service/controller/auth/AuthController.java
+++ b/src/main/java/org/turtle/minecraft_service/controller/auth/AuthController.java
@@ -1,0 +1,104 @@
+package org.turtle.minecraft_service.controller.auth;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.dto.auth.login.LoginDto;
+
+import org.turtle.minecraft_service.dto.auth.login.LoginRequestDto;
+import org.turtle.minecraft_service.dto.auth.login.LoginResponseDto;
+import org.turtle.minecraft_service.dto.auth.logout.LogoutResponseDto;
+import org.turtle.minecraft_service.dto.auth.signup.SignupDto;
+import org.turtle.minecraft_service.dto.auth.signup.SignupRequestDto;
+import org.turtle.minecraft_service.dto.auth.signup.SignupResponseDto;
+import org.turtle.minecraft_service.dto.auth.signup.nickname.NicknameDuplicationRequestDto;
+import org.turtle.minecraft_service.dto.auth.signup.nickname.NicknameDuplicationResponseDto;
+import org.turtle.minecraft_service.dto.auth.tokenReIssue.TokenReIssueDto;
+import org.turtle.minecraft_service.dto.auth.tokenReIssue.TokenReIssueResponseDto;
+import org.turtle.minecraft_service.service.auth.AuthService;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExample;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExamples;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "인증")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "닉네임 중복확인")
+    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = NicknameDuplicationResponseDto.class)))
+    @PostMapping("/check/nickname")
+    public ResponseEntity<NicknameDuplicationResponseDto> checkNickname(@Valid @RequestBody NicknameDuplicationRequestDto requestDto){
+        authService.checkNickname(requestDto);
+        return new ResponseEntity<>(NicknameDuplicationResponseDto.createNewResponse(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "회원 가입")
+    @ApiResponse(responseCode = "201", content = @Content(schema = @Schema(implementation = LoginResponseDto.class)))
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto){
+        SignupDto signup = authService.signup(requestDto);
+        return new ResponseEntity<>(SignupResponseDto.fromDto(signup), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "로그인")
+    @ApiErrorCodeExamples(value = {
+            @ApiErrorCodeExample(value = HttpErrorCode.ForbiddenKakaoError),
+            @ApiErrorCodeExample(value = HttpErrorCode.ForbiddenNaverError),
+            @ApiErrorCodeExample(value = HttpErrorCode.UnauthorizedKakaoError),
+            @ApiErrorCodeExample(value = HttpErrorCode.UnauthorizedNaverError),
+            @ApiErrorCodeExample(value = HttpErrorCode.UserNotFoundError),
+    })
+    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LoginResponseDto.class)))
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
+        LoginDto dto = authService.login(requestDto);
+        return new ResponseEntity<>(LoginResponseDto.fromDto(dto), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "로그아웃")
+    @ApiErrorCodeExamples(value = {
+            @ApiErrorCodeExample(value = HttpErrorCode.NoSuchRefreshTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.NotValidAccessTokenError)
+    })
+    @ApiResponse(responseCode = "201", content = @Content(schema = @Schema(implementation = LogoutResponseDto.class)))
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutResponseDto> logout(
+            @Schema(example = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3...")
+            @RequestHeader("Authorization-refresh") String refreshToken
+    ) {
+       authService.logout(refreshToken);
+       return new ResponseEntity<>(LogoutResponseDto.createNewResponse(), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "토큰 재발행")
+    @ApiErrorCodeExamples(value = {
+            @ApiErrorCodeExample(value = HttpErrorCode.NotValidTokenError, description = "토큰이 유효하지 않을 경우 발생하는 에러입니다."),
+            @ApiErrorCodeExample(value = HttpErrorCode.NotValidAccessTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.NoSuchRefreshTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.ExpiredRefreshTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.NoSuchAccessTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.UserNotFoundError, description = "AccessToken의 Payload에서 유저 정보를 추출할 수 없을 경우 발생하는 에러입니다.")
+    })
+    @ApiResponse(responseCode = "201", content = @Content(schema = @Schema(implementation = TokenReIssueResponseDto.class)))
+    @PostMapping("/refreshToken")
+    public ResponseEntity<TokenReIssueResponseDto> reIssueToken(
+            @Schema(example = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3...")
+            @RequestHeader("Authorization") String accessToken,
+            @Schema(example = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3...")
+            @RequestHeader("Authorization-refresh") String refreshToken
+    ){
+        TokenReIssueDto dto = authService.reIssueToken(accessToken, refreshToken);
+        return new ResponseEntity<>(TokenReIssueResponseDto.fromDto(dto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/controller/user/UserController.java
+++ b/src/main/java/org/turtle/minecraft_service/controller/user/UserController.java
@@ -1,0 +1,47 @@
+package org.turtle.minecraft_service.controller.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.domain.primary.User;
+import org.turtle.minecraft_service.dto.user.inquiry.UserInfoInquiryDto;
+import org.turtle.minecraft_service.dto.user.inquiry.UserInfoInquiryResponseDto;
+import org.turtle.minecraft_service.service.user.UserService;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExample;
+import org.turtle.minecraft_service.swagger.ApiErrorCodeExamples;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@Tag(name = "회원 정보")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원 정보 조회")
+    @ApiErrorCodeExamples(value = {
+            @ApiErrorCodeExample(value = HttpErrorCode.AccessDeniedError),
+            @ApiErrorCodeExample(value = HttpErrorCode.NotValidAccessTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.ExpiredAccessTokenError),
+            @ApiErrorCodeExample(value = HttpErrorCode.UserNotFoundError)
+    })
+    @GetMapping()
+    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = UserInfoInquiryResponseDto.class )))
+    public ResponseEntity<UserInfoInquiryResponseDto> getUserInfo(@AuthenticationPrincipal User user) {
+
+        UserInfoInquiryDto userInfoInquiryDto = userService.getUserInfo(user);
+
+        return new ResponseEntity<>(UserInfoInquiryResponseDto.fromDto(userInfoInquiryDto), HttpStatus.OK);
+
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/domain/User.java
+++ b/src/main/java/org/turtle/minecraft_service/domain/User.java
@@ -1,0 +1,73 @@
+package org.turtle.minecraft_service.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.turtle.minecraft_service.constant.SnsType;
+import org.turtle.minecraft_service.dto.auth.oauth.userInfo.OAuthUserInfoDto;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Entity(name = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class User implements OAuth2User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String snsId;
+
+    @Column(nullable = false, length = 50)
+    private SnsType snsType;
+
+    @Column(length = 255)
+    private String profileImage;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(length = 255)
+    private String email;
+
+    private String authority;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton((GrantedAuthority) () -> authority);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public static User of(OAuthUserInfoDto dto, String nickname){
+        return User.builder()
+                .snsId(dto.getSnsId())
+                .snsType(dto.getSnsType())
+                .name(dto.getName())
+                .nickname(nickname)
+                .email(dto.getEmail())
+                .build();
+    }
+
+
+}

--- a/src/main/java/org/turtle/minecraft_service/domain/primary/User.java
+++ b/src/main/java/org/turtle/minecraft_service/domain/primary/User.java
@@ -1,4 +1,4 @@
-package org.turtle.minecraft_service.domain;
+package org.turtle.minecraft_service.domain.primary;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -7,10 +7,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.turtle.minecraft_service.constant.SnsType;
 import org.turtle.minecraft_service.dto.auth.oauth.userInfo.OAuthUserInfoDto;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 @Entity(name = "users")

--- a/src/main/java/org/turtle/minecraft_service/domain/secondary/MinecraftUser.java
+++ b/src/main/java/org/turtle/minecraft_service/domain/secondary/MinecraftUser.java
@@ -1,0 +1,64 @@
+package org.turtle.minecraft_service.domain.secondary;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_detailed_info")
+@Getter
+@Setter
+public class MinecraftUser {
+
+    @Id
+    @Column(name = "player_uuid")
+    private UUID playerUuid;
+
+    @Column(name = "player_name")
+    private String playerName;
+
+    @Column(name = "money")
+    private double money;
+
+    @Column(name = "last_seen")
+    private LocalDateTime lastSeen;
+
+    @Column(name = "tag_name")
+    private String tagName;
+
+    @Column(name = "tag")
+    private String tag;
+
+    @Column(name = "primary_group")
+    private String primaryGroup;
+
+    @Column(name = "registrants")
+    private Long registrants;
+
+    @Column(name = "progress")
+    private Long progress;
+
+    @Column(name = "categories", columnDefinition = "TEXT")
+    private String categories;
+
+    @Column(name = "badgets_discoveries")
+    private Long badgetsDiscoveries;
+
+    @Column(name = "history_discoveries")
+    private Long historyDiscoveries;
+
+    @Column(name = "monsters_discoveries")
+    private Long monstersDiscoveries;
+
+    @Column(name = "regions_discoveries")
+    private Long regionsDiscoveries;
+
+
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginDto.java
@@ -1,0 +1,19 @@
+package org.turtle.minecraft_service.dto.auth.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoginDto {
+
+    private LoginToken token;
+
+    public static LoginDto of(String accessToken, String refreshToken) {
+        return LoginDto.builder()
+                .token(LoginToken.of(accessToken, refreshToken))
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginRequestDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginRequestDto.java
@@ -1,0 +1,22 @@
+package org.turtle.minecraft_service.dto.auth.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.turtle.minecraft_service.constant.SnsType;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LoginRequestDto {
+
+    @Schema(example = "Kakao", description = "토큰 발행 기관")
+    @NotNull(message = "소셜 계정의 타입이 필요합니다.")
+    private SnsType snsType;
+
+    @Schema(example = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIy...", description = "토큰 발행 기관에서 받은 AccessToken")
+    @NotNull(message = "accessToken이 필요합니다.")
+    private String accessToken;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginResponseDto.java
@@ -1,0 +1,26 @@
+package org.turtle.minecraft_service.dto.auth.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(name = "LoginResponseDto")
+public class LoginResponseDto {
+
+    @Schema(description = "응답 메시지", example = "성공적으로 로그인하였습니다!")
+    private String message;
+
+    @Schema(description = "서비스 토큰 정보")
+    private LoginToken token;
+
+    public static LoginResponseDto fromDto(LoginDto dto){
+        return LoginResponseDto.builder()
+                .message("성공적으로 로그인하였습니다!")
+                .token(dto.getToken())
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginToken.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/login/LoginToken.java
@@ -1,0 +1,25 @@
+package org.turtle.minecraft_service.dto.auth.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoginToken {
+
+    @Schema(description = "서비스 accessToken", example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIy...")
+    private String accessToken;
+
+    @Schema(description = "서비스 refreshToken", example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3...")
+    private String refreshToken;
+
+    public static LoginToken of(String accessToken, String refreshToken) {
+        return LoginToken.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/logout/LogoutResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/logout/LogoutResponseDto.java
@@ -1,0 +1,22 @@
+package org.turtle.minecraft_service.dto.auth.logout;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(name = "LogoutResponseDto")
+public class LogoutResponseDto {
+
+    @Schema(description = "응답 메시지", example = "성공적으로 로그아웃하였습니다!")
+    private String message;
+
+    public static LogoutResponseDto createNewResponse(){
+        return LogoutResponseDto.builder()
+                .message("성공적으로 로그아웃하였습니다!")
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/google/GoogleUserInfoResponse.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/google/GoogleUserInfoResponse.java
@@ -1,0 +1,28 @@
+package org.turtle.minecraft_service.dto.auth.oauth.google;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GoogleUserInfoResponse {
+
+    @JsonProperty("sub")
+    private String sub;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("given_name")
+    private String givenName;
+
+    @JsonProperty("picture")
+    private String picture;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("email_verified")
+    private Boolean emailVerified;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoAccount.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoAccount.java
@@ -1,0 +1,18 @@
+package org.turtle.minecraft_service.dto.auth.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoAccount {
+
+    @JsonProperty("profile_needs_agreement")
+    private boolean profileNeedsAgreement;
+
+    @JsonProperty("email_needs_agreement")
+    private boolean emailNeedsAgreement;
+
+    private KakaoUserProfile profile;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoProperties.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoProperties.java
@@ -1,0 +1,18 @@
+package org.turtle.minecraft_service.dto.auth.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoProperties {
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("profile_image")
+    private String profileImage;
+
+    @JsonProperty("thumbnail_image")
+    private String thumbnailImage;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,23 @@
+package org.turtle.minecraft_service.dto.auth.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Setter
+public class KakaoUserInfoResponse {
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("connected_at")
+    private ZonedDateTime connectedAt;
+
+    @JsonProperty("properties")
+    private KakaoProperties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoUserProfile.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/kakao/KakaoUserProfile.java
@@ -1,0 +1,24 @@
+package org.turtle.minecraft_service.dto.auth.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserProfile {
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("thumbnail_image_url")
+    private String thumbnailImageUrl;
+
+    @JsonProperty("profile_image_url")
+    private String profileImageUrl;
+
+    @JsonProperty("is_default_image")
+    private boolean isDefaultImage;
+
+    @JsonProperty("is_default_nickname")
+    private boolean isDefaultNickname;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/naver/NaverResponseDetails.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/naver/NaverResponseDetails.java
@@ -1,0 +1,39 @@
+package org.turtle.minecraft_service.dto.auth.oauth.naver;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NaverResponseDetails {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("gender")
+    private String gender;
+
+    @JsonProperty("age")
+    private String age;
+
+    @JsonProperty("birthday")
+    private String birthday;
+
+    @JsonProperty("profile_image")
+    private String profileImage;
+
+    @JsonProperty("birthyear")
+    private String birthyear;
+
+    @JsonProperty("mobile")
+    private String mobile;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/naver/NaverUserInfoResponse.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/naver/NaverUserInfoResponse.java
@@ -1,0 +1,19 @@
+package org.turtle.minecraft_service.dto.auth.oauth.naver;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NaverUserInfoResponse {
+    @JsonProperty("resultcode")
+    private String resultCode;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("response")
+    private NaverResponseDetails responseDetails;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/userInfo/OAuthUserInfoDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/oauth/userInfo/OAuthUserInfoDto.java
@@ -1,0 +1,47 @@
+package org.turtle.minecraft_service.dto.auth.oauth.userInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.turtle.minecraft_service.constant.SnsType;
+import org.turtle.minecraft_service.dto.auth.oauth.google.GoogleUserInfoResponse;
+import org.turtle.minecraft_service.dto.auth.oauth.kakao.KakaoUserInfoResponse;
+import org.turtle.minecraft_service.dto.auth.oauth.naver.NaverUserInfoResponse;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OAuthUserInfoDto {
+    private String snsId;
+    private SnsType snsType;
+    private String name;
+    private String email;
+
+    public static OAuthUserInfoDto from(GoogleUserInfoResponse googleUserInfoResponse){
+        return OAuthUserInfoDto.builder()
+                .snsId(googleUserInfoResponse.getSub())
+                .snsType(SnsType.Google)
+                .name(googleUserInfoResponse.getName())
+                .email(googleUserInfoResponse.getEmail())
+                .build();
+    }
+
+    public static OAuthUserInfoDto from(KakaoUserInfoResponse kakaoUserInfoResponse){
+        return OAuthUserInfoDto.builder()
+                .snsId(String.valueOf(kakaoUserInfoResponse.getId()))
+                .snsType(SnsType.Kakao)
+                .name(kakaoUserInfoResponse.getKakaoAccount().getProfile().getNickname())
+                .email(null)
+                .build();
+    }
+
+    public static OAuthUserInfoDto from(NaverUserInfoResponse naverUserInfoResponse){
+        return OAuthUserInfoDto.builder()
+                .snsId(String.valueOf(naverUserInfoResponse.getResponseDetails().getId()))
+                .snsType(SnsType.Naver)
+                .name(naverUserInfoResponse.getResponseDetails().getName())
+                .email(naverUserInfoResponse.getResponseDetails().getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupDto.java
@@ -1,0 +1,22 @@
+package org.turtle.minecraft_service.dto.auth.signup;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.turtle.minecraft_service.dto.auth.login.LoginToken;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SignupDto {
+
+    private LoginToken token;
+
+    public static SignupDto of(String accessToken, String refreshToken) {
+        return SignupDto.builder()
+                .token(LoginToken.of(accessToken, refreshToken))
+                .build();
+
+    }
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupRequestDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupRequestDto.java
@@ -1,0 +1,29 @@
+package org.turtle.minecraft_service.dto.auth.signup;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.turtle.minecraft_service.constant.SnsType;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class SignupRequestDto {
+
+    @Schema(example = "Kakao", description = "토큰 발행 기관")
+    @NotNull(message = "소셜 계정의 타입이 필요합니다.")
+    private SnsType snsType;
+
+    @Schema(example = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIy...", description = "토큰 발행 기관에서 받은 AccessToken")
+    @NotNull(message = "accessToken이 필요합니다.")
+    private String accessToken;
+
+    @Schema(example = "kkOma_fan", description = "거북이 놀이터 서버에서 사용하고 있는 닉네임")
+    @NotNull(message = "닉네임이 필요합니다.")
+    @Size(min = 2, max = 16, message = "닉네임은 2글자에서 16글자만 허용됩니다.")
+    private String nickname;
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/signup/SignupResponseDto.java
@@ -1,0 +1,28 @@
+package org.turtle.minecraft_service.dto.auth.signup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.turtle.minecraft_service.dto.auth.login.LoginToken;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(name = "SignupResponse")
+public class SignupResponseDto {
+
+    @Schema(description = "응답 메시지", example = "성공적으로 회원가입 하였습니다!")
+    private String message;
+
+    @Schema(description = "서비스 토큰 정보")
+    private LoginToken token;
+
+    public static SignupResponseDto fromDto(SignupDto dto){
+        return SignupResponseDto.builder()
+                .message("성공적으로 회원가입 하였습니다!")
+                .token(dto.getToken())
+                .build();
+    }
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/signup/nickname/NicknameDuplicationRequestDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/signup/nickname/NicknameDuplicationRequestDto.java
@@ -1,0 +1,15 @@
+package org.turtle.minecraft_service.dto.auth.signup.nickname;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NicknameDuplicationRequestDto {
+
+    @Schema(example = "kkOma_fan", description = "거북이 놀이터에서 사용중인 실제 닉네임")
+    @NotNull(message = "닉네임이 필요합니다.")
+    private String nickname;
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/signup/nickname/NicknameDuplicationResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/signup/nickname/NicknameDuplicationResponseDto.java
@@ -1,0 +1,26 @@
+package org.turtle.minecraft_service.dto.auth.signup.nickname;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(name = "NicknameDuplicationResponseDto")
+public class NicknameDuplicationResponseDto {
+
+    @Schema(description = "응답 메시지", example = "해당 닉네임으로 소셜 계정을 생성할 수 있습니다!")
+    private String message;
+
+    public static NicknameDuplicationResponseDto createNewResponse(){
+        return NicknameDuplicationResponseDto.builder()
+                .message("해당 닉네임으로 소셜 계정을 생성할 수 있습니다!")
+                .build();
+    }
+
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/tokenReIssue/TokenReIssueDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/tokenReIssue/TokenReIssueDto.java
@@ -1,0 +1,22 @@
+package org.turtle.minecraft_service.dto.auth.tokenReIssue;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TokenReIssueDto {
+
+    private String message;
+
+    private String accessToken;
+
+    public static TokenReIssueDto of(String reIssuedAccessToken){
+        return TokenReIssueDto.builder()
+                .message("토큰이 재발행되었습니다!")
+                .accessToken(reIssuedAccessToken)
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/auth/tokenReIssue/TokenReIssueResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/auth/tokenReIssue/TokenReIssueResponseDto.java
@@ -1,0 +1,26 @@
+package org.turtle.minecraft_service.dto.auth.tokenReIssue;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(name = "TokenReIssueResponseDto")
+public class TokenReIssueResponseDto {
+
+    @Schema(description = "응답 메시지", example = "토큰이 재발행되었습니다!")
+    private String message;
+
+    @Schema(description = "재발행된 서비스 accessToken", example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIy...")
+    private String accessToken;
+
+    public static TokenReIssueResponseDto fromDto(TokenReIssueDto dto){
+        return TokenReIssueResponseDto.builder()
+                .message(dto.getMessage())
+                .accessToken(dto.getAccessToken())
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/user/inquiry/UserInfoInquiryDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/user/inquiry/UserInfoInquiryDto.java
@@ -1,0 +1,52 @@
+package org.turtle.minecraft_service.dto.user.inquiry;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.turtle.minecraft_service.constant.SnsType;
+import org.turtle.minecraft_service.domain.primary.User;
+import org.turtle.minecraft_service.domain.secondary.MinecraftUser;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserInfoInquiryDto {
+
+    private SnsType snsType;
+
+    private String nickname;
+
+    private double money;
+
+    private LocalDateTime lastLogin;
+
+    private String title;
+
+    private Long progress;
+
+    private Long badgeDiscovered;
+
+    private Long historyDiscovered;
+
+    private Long monstersDiscovered;
+
+    private Long regionsDiscovered;
+
+    public static UserInfoInquiryDto of(User user, MinecraftUser minecraftUser){
+        return UserInfoInquiryDto.builder()
+                .snsType(user.getSnsType())
+                .nickname(minecraftUser.getPlayerName())
+                .money(minecraftUser.getMoney())
+                .lastLogin(minecraftUser.getLastSeen())
+                .title(minecraftUser.getTag())
+                .progress(minecraftUser.getProgress())
+                .badgeDiscovered(minecraftUser.getBadgetsDiscoveries())
+                .historyDiscovered(minecraftUser.getHistoryDiscoveries())
+                .monstersDiscovered(minecraftUser.getMonstersDiscoveries())
+                .regionsDiscovered(minecraftUser.getRegionsDiscoveries())
+                .build();
+    }
+
+}

--- a/src/main/java/org/turtle/minecraft_service/dto/user/inquiry/UserInfoInquiryResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/dto/user/inquiry/UserInfoInquiryResponseDto.java
@@ -1,0 +1,51 @@
+package org.turtle.minecraft_service.dto.user.inquiry;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.turtle.minecraft_service.constant.SnsType;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserInfoInquiryResponseDto {
+
+    private SnsType snsType;
+
+    private String nickname;
+
+    private double money;
+
+    private LocalDateTime lastLogin;
+
+    private String title;
+
+    private Long progress;
+
+    private Long badgeDiscovered;
+
+    private Long historyDiscovered;
+
+    private Long monstersDiscovered;
+
+    private Long regionsDiscovered;
+
+
+    public static UserInfoInquiryResponseDto fromDto(UserInfoInquiryDto dto){
+        return UserInfoInquiryResponseDto.builder()
+                .snsType(dto.getSnsType())
+                .nickname(dto.getNickname())
+                .money(dto.getMoney())
+                .lastLogin(dto.getLastLogin())
+                .title(dto.getTitle())
+                .progress(dto.getProgress())
+                .badgeDiscovered(dto.getBadgeDiscovered())
+                .historyDiscovered(dto.getHistoryDiscovered())
+                .monstersDiscovered(dto.getMonstersDiscovered())
+                .regionsDiscovered(dto.getRegionsDiscovered())
+                .build();
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/exception/ApiExceptionHandler.java
+++ b/src/main/java/org/turtle/minecraft_service/exception/ApiExceptionHandler.java
@@ -1,0 +1,102 @@
+package org.turtle.minecraft_service.exception;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ApiExceptionHandler {
+    @ExceptionHandler(HttpErrorException.class)
+    @JsonView(CustomJsonView.Summary.class)
+    protected ResponseEntity<ErrorResponseDto> handleCustomErrorException(HttpErrorException e) {
+        log.error(e.getMessage());
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.from(e.getHttpErrorCode());
+        return new ResponseEntity<>(errorResponseDto, e.getHttpErrorCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @JsonView(CustomJsonView.Entire.class)
+    protected ResponseEntity<ErrorResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorResponseDto.ErrorDescription errorDescription
+                = ErrorResponseDto.ErrorDescription.of(HttpErrorCode.QueryParamTypeMismatchError.getMessage());
+        List<ErrorResponseDto.ErrorDescription> ErrorDescriptions
+                = List.of(errorDescription);
+
+        ErrorResponseDto notValidRequestErrorResponseDto
+                = ErrorResponseDto.of(ErrorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @JsonView(CustomJsonView.Entire.class)
+    protected ResponseEntity<ErrorResponseDto> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        ErrorResponseDto.ErrorDescription errorDescription
+                = ErrorResponseDto.ErrorDescription.of(HttpErrorCode.MissingQueryParamError.getMessage());
+        List<ErrorResponseDto.ErrorDescription> ErrorDescriptions
+                = List.of(errorDescription);
+
+        ErrorResponseDto notValidRequestErrorResponseDto
+                = ErrorResponseDto.of(ErrorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @JsonView(CustomJsonView.Summary.class)
+    protected ResponseEntity<ErrorResponseDto> handleAccessDeniedException(AccessDeniedException e) {
+        ErrorResponseDto errorResponseDto =
+                ErrorResponseDto.from(HttpErrorCode.AccessDeniedError);
+
+        return new ResponseEntity<>(errorResponseDto, HttpErrorCode.AccessDeniedError.getHttpStatus());
+    }
+
+    @ExceptionHandler(BindException.class)
+    @JsonView(CustomJsonView.Entire.class)
+    protected ResponseEntity<ErrorResponseDto> handleBindException(BindException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+        List<ErrorResponseDto.ErrorDescription> errorDescriptions =
+                fieldErrors.stream().map(ErrorResponseDto.ErrorDescription::of).toList();
+
+        ErrorResponseDto notValidRequestErrorResponseDto =
+                ErrorResponseDto.of(e, errorDescriptions);
+
+        return new ResponseEntity<>(notValidRequestErrorResponseDto, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    @JsonView(CustomJsonView.Summary.class)
+    public ResponseEntity<ErrorResponseDto> handleMissingHeader(MissingRequestHeaderException e) {
+        HttpErrorCode missingRequestHeaderError = HttpErrorCode.MissingRequestHeaderError;
+        return new ResponseEntity<>(ErrorResponseDto.from(missingRequestHeaderError), missingRequestHeaderError.getHttpStatus());
+    }
+
+    @ExceptionHandler(InternalAuthenticationServiceException.class)
+    @JsonView(CustomJsonView.Summary.class)
+    protected ResponseEntity<ErrorResponseDto> HandleInternalAuthenticationServiceException(Exception e) {
+        return new ResponseEntity<>(ErrorResponseDto.from(HttpErrorCode.InternalServerError), HttpErrorCode.InternalServerError.getHttpStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @JsonView(CustomJsonView.Summary.class)
+    protected ResponseEntity<ErrorResponseDto> HandleGeneralException(Exception e) {
+        return new ResponseEntity<>(ErrorResponseDto.from(HttpErrorCode.InternalServerError), HttpErrorCode.InternalServerError.getHttpStatus());
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/exception/CustomJsonView.java
+++ b/src/main/java/org/turtle/minecraft_service/exception/CustomJsonView.java
@@ -1,0 +1,9 @@
+package org.turtle.minecraft_service.exception;
+
+public class CustomJsonView {
+    public static class Summary {
+    }
+
+    public static class Entire extends Summary {
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/exception/ErrorResponseDto.java
+++ b/src/main/java/org/turtle/minecraft_service/exception/ErrorResponseDto.java
@@ -1,0 +1,119 @@
+package org.turtle.minecraft_service.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ErrorResponseDto {
+    @JsonView(CustomJsonView.Summary.class)
+    private String errorCode;
+    @JsonView(CustomJsonView.Summary.class)
+    private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonView(CustomJsonView.Entire.class)
+    private List<ErrorDescription> errorDescriptions;
+
+    public static ErrorResponseDto of(List<ErrorDescription> errorDescription){
+        return ErrorResponseDto.builder()
+                .errorCode(HttpErrorCode.NotValidRequestError.name())
+                .message(HttpErrorCode.NotValidRequestError.getMessage())
+                .errorDescriptions(errorDescription)
+                .build();
+    }
+
+    public static ErrorResponseDto of(BindException e, List<ErrorDescription> errorDescription){
+        return ErrorResponseDto.builder()
+                .errorCode(HttpErrorCode.NotValidRequestError.name())
+                .message(HttpErrorCode.NotValidRequestError.getMessage())
+                .errorDescriptions(errorDescription)
+                .build();
+    }
+
+    public static ErrorResponseDto from(HttpErrorCode httpErrorCode){
+        return ErrorResponseDto.builder()
+                .errorCode(httpErrorCode.name())
+                .message(httpErrorCode.getMessage())
+                .build();
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Builder
+    public static class ErrorDescription{
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonView(CustomJsonView.Entire.class)
+        private String message;
+
+        public static ErrorDescription of(String message){
+            return ErrorDescription.builder()
+                    .message(message)
+                    .build();
+        }
+
+
+        public static ErrorDescription of(FieldError error){
+            return ErrorDescription.builder()
+                    .message(error.getDefaultMessage())
+                    .build();
+        }
+    }
+
+
+}
+
+
+//package org.team200ok.togethergyeongju.exception;
+//
+//import io.swagger.v3.oas.annotations.media.Schema;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.Setter;
+//import org.team200ok.togethergyeongju.config.HttpErrorCode;
+//
+//@Getter
+//@Setter
+//@AllArgsConstructor
+//@Builder
+//@Schema(title = "API 응답 - 실패 및 에러")
+//public class ErrorResponseDto {
+//    @Schema(description = "응답 코드", example = "400")
+//    private String errorCode;
+//
+//    @Schema(description = "응답 메시지", example = "에러 이유")
+//    private String message;
+//
+//    public static ErrorResponseDto fromException(HttpErrorException e){
+//        return ErrorResponseDto.builder()
+//                .errorCode(e.getHttpErrorCode().name())
+//                .message(e.getMessage())
+//                .build();
+//    }
+//
+//    public static ErrorResponseDto from(HttpErrorCode httpErrorCode){
+//        return ErrorResponseDto.builder()
+//                .errorCode(httpErrorCode.name())
+//                .message(httpErrorCode.getMessage())
+//                .build();
+//    }
+//
+//    public static ErrorResponseDto of(String errorCode, String message){
+//        return ErrorResponseDto.builder()
+//                .errorCode(errorCode)
+//                .message(message)
+//                .build();
+//    }
+//}

--- a/src/main/java/org/turtle/minecraft_service/exception/HttpErrorException.java
+++ b/src/main/java/org/turtle/minecraft_service/exception/HttpErrorException.java
@@ -1,0 +1,15 @@
+package org.turtle.minecraft_service.exception;
+
+import lombok.Getter;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+
+@Getter
+public class HttpErrorException extends RuntimeException{
+    private final HttpErrorCode httpErrorCode;
+
+    public HttpErrorException(HttpErrorCode httpErrorCode){
+        super(httpErrorCode.getMessage());
+        this.httpErrorCode = httpErrorCode;
+    }
+}
+

--- a/src/main/java/org/turtle/minecraft_service/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/turtle/minecraft_service/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package org.turtle.minecraft_service.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.constant.TokenType;
+import org.turtle.minecraft_service.exception.ErrorResponseDto;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import org.turtle.minecraft_service.provider.JwtTokenProvider;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+        try {
+            String accessToken = request.getHeader("Authorization");
+            if(accessToken == null){
+                throw new HttpErrorException(HttpErrorCode.AccessDeniedError);
+            }
+
+            String resolvedAccessToken = jwtTokenProvider.resolveAccessToken(accessToken);
+            jwtTokenProvider.validateToken(TokenType.ACCESS_TOKEN, resolvedAccessToken);
+
+            Authentication authentication = jwtTokenProvider.getAuthentication(resolvedAccessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            jwtExceptionHandler(response, e);
+        }
+    }
+
+    // 토큰에 대한 오류가 발생했을 때, 커스터마이징해서 Exception 처리 값을 클라이언트에게 알려준다.
+    public void jwtExceptionHandler(HttpServletResponse response, Exception e) {
+        HttpErrorCode httpErrorCode = HttpErrorCode.InternalServerError;
+        if (e instanceof HttpErrorException) {
+            httpErrorCode = ((HttpErrorException) e).getHttpErrorCode();
+        }
+
+        response.setStatus(httpErrorCode.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        try {
+            String json = new ObjectMapper().writeValueAsString(ErrorResponseDto.from(httpErrorCode));
+            response.getWriter().write(json);
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/provider/JwtTokenProvider.java
+++ b/src/main/java/org/turtle/minecraft_service/provider/JwtTokenProvider.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.turtle.minecraft_service.config.HttpErrorCode;
 import org.turtle.minecraft_service.constant.TokenType;
-import org.turtle.minecraft_service.domain.User;
+import org.turtle.minecraft_service.domain.primary.User;
 import org.turtle.minecraft_service.exception.HttpErrorException;
-import org.turtle.minecraft_service.repository.UserRepository;
+import org.turtle.minecraft_service.repository.primary.UserRepository;
 
 import java.security.Key;
 import java.util.Date;

--- a/src/main/java/org/turtle/minecraft_service/provider/JwtTokenProvider.java
+++ b/src/main/java/org/turtle/minecraft_service/provider/JwtTokenProvider.java
@@ -1,0 +1,181 @@
+package org.turtle.minecraft_service.provider;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.constant.TokenType;
+import org.turtle.minecraft_service.domain.User;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import org.turtle.minecraft_service.repository.UserRepository;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+    private final UserRepository userRepository;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, UserRepository userRepository) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 사용자의 snsId를 이용하여 AccessToken을 생성한다.
+     * @param snsId
+     * @return accessToken
+     */
+    public String generateAccessToken(String snsId) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(snsId)); // subject
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims) //정보 저장
+                .setIssuedAt(now) //토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * refreshToken을 생성한다.
+     * @return refreshToken
+     */
+    public String generateRefreshToken() {
+        Date now = new Date();
+
+        // Refresh Token 생성
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setExpiration(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * accessToken을 파싱하여 인증 객체(Authentication) 반환한다
+     * @param accessToken
+     * @return Authentication
+     * @throws HttpErrorException
+     */
+    public Authentication getAuthentication(String accessToken){
+        Claims claims = parseClaims(accessToken);
+
+        if(claims.get("sub") == null){
+            throw new HttpErrorException(HttpErrorCode.NotValidAccessTokenError);
+        }
+
+        String username = claims.get("sub").toString(); // 복호화된 accessToken 에서 사용자 id 추출
+        User user = userRepository.findBySnsId(username).orElseThrow(() -> new HttpErrorException(HttpErrorCode.UserNotFoundError));
+
+        return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
+    }
+
+    /**
+     * 토큰 정보를 검증한다
+     * @param tokenType
+     * @param token
+     * @throws HttpErrorException
+     */
+    public void validateToken(TokenType tokenType, String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (SignatureException | SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            if (tokenType == TokenType.ACCESS_TOKEN) throw new HttpErrorException(HttpErrorCode.NotValidAccessTokenError);
+            if (tokenType == TokenType.REFRESH_TOKEN) throw new HttpErrorException(HttpErrorCode.NotValidRefreshTokenError);
+        } catch (ExpiredJwtException e) {
+            if (tokenType == TokenType.ACCESS_TOKEN) throw new HttpErrorException(HttpErrorCode.ExpiredAccessTokenError);
+            if (tokenType == TokenType.REFRESH_TOKEN) throw new HttpErrorException(HttpErrorCode.ExpiredRefreshTokenError);
+        }
+    }
+
+    /**
+     * 토큰 만료여부를 확인한다.
+     * @param token
+     * @return boolean
+     * @throws HttpErrorException
+     */
+    public boolean isExpiredToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            return true;
+        } catch (Exception e) {
+            throw new HttpErrorException(HttpErrorCode.NotValidTokenError);
+        }
+
+        return false;
+    }
+
+    /**
+     * token의 인증타입(Bearer)을 제거하여 반환
+     * @param token
+     * @return 인증타입(Bearer)을 제거한 token
+     * @throws HttpErrorException 토큰이 유효하지 않을 경우 에러를 던진다.
+     */
+    public String resolveToken(String token) {
+        if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
+            return token.substring(7);
+        }
+
+        throw new HttpErrorException(HttpErrorCode.NotValidTokenError);
+    }
+
+    /**
+     * accessToken의 인증타입(Bearer)을 제거하여 반환
+     * @param accessToken
+     * @return 인증타입(Bearer)을 제거한 token
+     * @throws HttpErrorException 토큰이 유효하지 않을 경우 에러를 던진다.
+     */
+    public String resolveAccessToken(String accessToken) {
+        if (StringUtils.hasText(accessToken) && accessToken.startsWith("Bearer")) {
+            return accessToken.substring(7);
+        }
+
+        throw new HttpErrorException(HttpErrorCode.NotValidAccessTokenError);
+    }
+
+    /**
+     * AccessToken 재발급
+     * @param accessToken
+     * @return 재발급된 accessToken
+     */
+    public String reIssueAccessToken(String accessToken) {
+        Authentication authentication = getAuthentication(accessToken);
+        Claims claims = Jwts.claims().setSubject(String.valueOf(((User) authentication.getPrincipal()).getSnsId())); // subject
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims) //정보 저장
+                .setIssuedAt(now) //토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Claims parseClaims(String accessToken){
+        try{
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/repository/UserRepository.java
+++ b/src/main/java/org/turtle/minecraft_service/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package org.turtle.minecraft_service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.turtle.minecraft_service.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository  extends JpaRepository<User, Long> {
+    Optional<User> findBySnsId(String snsId);
+    Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/org/turtle/minecraft_service/repository/primary/UserRepository.java
+++ b/src/main/java/org/turtle/minecraft_service/repository/primary/UserRepository.java
@@ -1,7 +1,7 @@
-package org.turtle.minecraft_service.repository;
+package org.turtle.minecraft_service.repository.primary;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.turtle.minecraft_service.domain.User;
+import org.turtle.minecraft_service.domain.primary.User;
 
 import java.util.Optional;
 

--- a/src/main/java/org/turtle/minecraft_service/repository/secondary/MinecraftRepository.java
+++ b/src/main/java/org/turtle/minecraft_service/repository/secondary/MinecraftRepository.java
@@ -1,0 +1,15 @@
+package org.turtle.minecraft_service.repository.secondary;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.turtle.minecraft_service.domain.secondary.MinecraftUser;
+
+import java.util.Optional;
+
+
+public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> {
+
+   Optional<MinecraftUser> findByPlayerName(String nickname);
+}

--- a/src/main/java/org/turtle/minecraft_service/service/auth/AuthService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/auth/AuthService.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.turtle.minecraft_service.config.HttpErrorCode;
 import org.turtle.minecraft_service.constant.SnsType;
-import org.turtle.minecraft_service.domain.User;
+import org.turtle.minecraft_service.domain.primary.User;
 import org.turtle.minecraft_service.dto.auth.login.LoginDto;
 import org.turtle.minecraft_service.dto.auth.login.LoginRequestDto;
 import org.turtle.minecraft_service.dto.auth.signup.SignupDto;
@@ -18,7 +18,7 @@ import org.turtle.minecraft_service.dto.auth.oauth.userInfo.OAuthUserInfoDto;
 import org.turtle.minecraft_service.dto.auth.tokenReIssue.TokenReIssueDto;
 import org.turtle.minecraft_service.exception.HttpErrorException;
 import org.turtle.minecraft_service.provider.JwtTokenProvider;
-import org.turtle.minecraft_service.repository.UserRepository;
+import org.turtle.minecraft_service.repository.primary.UserRepository;
 import org.turtle.minecraft_service.service.redis.RedisService;
 
 import java.util.Optional;

--- a/src/main/java/org/turtle/minecraft_service/service/auth/AuthService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/auth/AuthService.java
@@ -1,0 +1,135 @@
+package org.turtle.minecraft_service.service.auth;
+
+
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.constant.SnsType;
+import org.turtle.minecraft_service.domain.User;
+import org.turtle.minecraft_service.dto.auth.login.LoginDto;
+import org.turtle.minecraft_service.dto.auth.login.LoginRequestDto;
+import org.turtle.minecraft_service.dto.auth.signup.SignupDto;
+import org.turtle.minecraft_service.dto.auth.signup.SignupRequestDto;
+import org.turtle.minecraft_service.dto.auth.signup.nickname.NicknameDuplicationRequestDto;
+import org.turtle.minecraft_service.dto.auth.oauth.userInfo.OAuthUserInfoDto;
+import org.turtle.minecraft_service.dto.auth.tokenReIssue.TokenReIssueDto;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import org.turtle.minecraft_service.provider.JwtTokenProvider;
+import org.turtle.minecraft_service.repository.UserRepository;
+import org.turtle.minecraft_service.service.redis.RedisService;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AuthService {
+    private final GoogleOAuthService googleOAuthService;
+    private final KakaoOAuthService kakaoOAuthService;
+    private final NaverOAuthService naverOAuthService;
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
+
+    public void checkNickname(@Valid NicknameDuplicationRequestDto requestDto){
+        Optional<User> user = userRepository.findByNickname(requestDto.getNickname());
+        if(user.isPresent()){
+            throw new HttpErrorException(HttpErrorCode.AlreadyExistNicknameError);
+        }
+    }
+
+
+    public SignupDto signup(@Valid SignupRequestDto requestDto){
+        OAuthUserInfoDto userInfo = getUserInfo(requestDto.getSnsType(), requestDto.getAccessToken());
+        Optional<User> user = userRepository.findBySnsId(userInfo.getSnsId());
+        if (user.isPresent()){
+            throw new HttpErrorException(HttpErrorCode.AlreadyExistUserError);
+        }
+
+        userRepository.save(User.of(userInfo, requestDto.getNickname()));
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userInfo.getSnsId());
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+        redisService.save(refreshToken, accessToken);
+
+        return SignupDto.of(accessToken, refreshToken);
+    }
+
+    public LoginDto login(@Valid LoginRequestDto requestDto){
+        OAuthUserInfoDto userInfo = getUserInfo(requestDto.getSnsType(), requestDto.getAccessToken());
+        Optional<User> user = userRepository.findBySnsId(userInfo.getSnsId());
+        if (user.isEmpty()){
+            throw new HttpErrorException(HttpErrorCode.UserNotFoundError);
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userInfo.getSnsId());
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+        redisService.save(refreshToken, accessToken);
+
+        return LoginDto.of(accessToken, refreshToken);
+    }
+
+    public void logout(String refreshToken){
+        String resolvedRefreshToken = jwtTokenProvider.resolveToken(refreshToken);
+
+        Optional<String> savedAccessToken = redisService.get(resolvedRefreshToken);
+        if(savedAccessToken.isEmpty()){
+            throw new HttpErrorException(HttpErrorCode.NoSuchRefreshTokenError);
+        }
+
+        redisService.delete(resolvedRefreshToken);
+
+    }
+
+    public TokenReIssueDto reIssueToken(String accessToken, String refreshToken){
+
+        String resolvedAccessToken = jwtTokenProvider.resolveToken(accessToken);
+        String resolvedRefreshToken = jwtTokenProvider.resolveToken(refreshToken);
+
+        String savedAccessToken = redisService.get(resolvedRefreshToken)
+                .orElseThrow(() -> new HttpErrorException(HttpErrorCode.NoSuchRefreshTokenError));
+
+        // RefreshToken 유효성 및 만료여부 확인
+        boolean isExpiredRefreshToken = jwtTokenProvider.isExpiredToken(resolvedRefreshToken);
+        if (isExpiredRefreshToken) {
+            redisService.delete(resolvedAccessToken);
+            throw new HttpErrorException(HttpErrorCode.ExpiredRefreshTokenError);
+        }
+
+        // RefreshToken이 탈취 당한 경우
+        if (!resolvedAccessToken.equals(savedAccessToken)) {
+            redisService.delete(resolvedAccessToken);
+            throw new HttpErrorException(HttpErrorCode.NoSuchAccessTokenError);
+        }
+
+        // AccessToken 유효성 및 만료여부 확인
+        boolean isExpiredAccessToken = jwtTokenProvider.isExpiredToken(resolvedAccessToken);
+        if (!isExpiredAccessToken) {
+            redisService.delete(resolvedRefreshToken);
+            throw new HttpErrorException(HttpErrorCode.NotExpiredAccessTokenError);
+        }
+
+        // 토큰 재발행
+        String reIssuedAccessToken = jwtTokenProvider.reIssueAccessToken(resolvedAccessToken);
+        redisService.delete(resolvedAccessToken);
+        redisService.save(resolvedRefreshToken, reIssuedAccessToken);
+        return TokenReIssueDto.of(reIssuedAccessToken);
+    }
+
+
+    private OAuthUserInfoDto getUserInfo(SnsType snsType, String accessToken) {
+        return switch (snsType) {
+            case Google -> OAuthUserInfoDto.from(googleOAuthService.getUserInfo(accessToken));
+            case Kakao -> OAuthUserInfoDto.from(kakaoOAuthService.getUserInfo(accessToken));
+            case Naver -> OAuthUserInfoDto.from(naverOAuthService.getUserInfo(accessToken));
+        };
+    }
+
+}

--- a/src/main/java/org/turtle/minecraft_service/service/auth/GoogleOAuthService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/auth/GoogleOAuthService.java
@@ -1,0 +1,42 @@
+package org.turtle.minecraft_service.service.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.dto.auth.oauth.google.GoogleUserInfoResponse;
+import org.turtle.minecraft_service.dto.auth.oauth.kakao.KakaoUserInfoResponse;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+public class GoogleOAuthService {
+
+    private final WebClient webClient;
+
+    public GoogleOAuthService(@Qualifier("googleWebClient") WebClient webClient){ this.webClient = webClient; }
+
+    public GoogleUserInfoResponse getUserInfo(String accessToken){
+        return webClient.get()
+                .uri("oauth2/v3/userinfo")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(status -> status.value() == 401,
+                        this::handle401Error)
+                .onStatus(status -> status.value() == 403,
+                        this::handle403Error)
+                .bodyToMono(GoogleUserInfoResponse.class)
+                .block();
+    }
+
+    private Mono<Throwable> handle401Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.UnauthorizedGoogleError));
+    }
+
+    private Mono<Throwable> handle403Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.ForbiddenGoogleError));
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/service/auth/KakaoOAuthService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/auth/KakaoOAuthService.java
@@ -1,0 +1,43 @@
+package org.turtle.minecraft_service.service.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.dto.auth.oauth.kakao.KakaoUserInfoResponse;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+public class KakaoOAuthService {
+
+    private final WebClient webClient;
+
+    public KakaoOAuthService(@Qualifier("kakaoWebClient")WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken){
+        return webClient.get()
+                .uri("v2/user/me")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(status -> status.value() == 401,
+                        this::handle401Error)
+                .onStatus(status -> status.value() == 403,
+                        this::handle403Error)
+                .bodyToMono(KakaoUserInfoResponse.class)
+                .block();
+    }
+
+    private Mono<Throwable> handle401Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.UnauthorizedKakaoError));
+    }
+
+    private Mono<Throwable> handle403Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.ForbiddenKakaoError));
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/service/auth/NaverOAuthService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/auth/NaverOAuthService.java
@@ -1,0 +1,41 @@
+package org.turtle.minecraft_service.service.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.dto.auth.oauth.naver.NaverUserInfoResponse;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+public class NaverOAuthService {
+
+    private final WebClient webClient;
+
+    public NaverOAuthService(@Qualifier("naverWebClient")WebClient webClient){ this.webClient = webClient; }
+
+    public NaverUserInfoResponse getUserInfo(String accessToken) {
+        return webClient.get()
+                .uri("v1/nid/me")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(status -> status.value() == 401,
+                        this::handle401Error)
+                .onStatus(status -> status.value() == 403,
+                        this::handle403Error)
+                .bodyToMono(NaverUserInfoResponse.class)
+                .block();
+    }
+
+    private Mono<Throwable> handle401Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.UnauthorizedNaverError));
+    }
+
+    private Mono<Throwable> handle403Error(ClientResponse response) {
+        return Mono.error(new HttpErrorException(HttpErrorCode.ForbiddenNaverError));
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/service/redis/RedisService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/redis/RedisService.java
@@ -1,0 +1,37 @@
+package org.turtle.minecraft_service.service.redis;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RedisService {
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(String key, String value) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public Optional<String> get(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return Optional.ofNullable(valueOperations.get(key));
+    }
+
+    public void delete(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String deletedData = valueOperations.getAndDelete(key);
+        if (deletedData == null) {
+            throw new HttpErrorException(HttpErrorCode.InternalServerError);
+        }
+    }
+}

--- a/src/main/java/org/turtle/minecraft_service/service/user/UserService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/user/UserService.java
@@ -1,0 +1,33 @@
+package org.turtle.minecraft_service.service.user;
+
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.turtle.minecraft_service.config.HttpErrorCode;
+import org.turtle.minecraft_service.domain.primary.User;
+import org.turtle.minecraft_service.domain.secondary.MinecraftUser;
+import org.turtle.minecraft_service.dto.user.inquiry.UserInfoInquiryDto;
+import org.turtle.minecraft_service.exception.HttpErrorException;
+import org.turtle.minecraft_service.repository.secondary.MinecraftRepository;
+
+@Service
+@AllArgsConstructor
+@Transactional
+@Slf4j
+public class UserService {
+
+    private final MinecraftRepository minecraftRepository;
+
+    public UserInfoInquiryDto getUserInfo(User user){
+
+        MinecraftUser minecraftUser =  minecraftRepository.findByPlayerName(user.getNickname())
+                .orElseThrow(() -> new HttpErrorException(HttpErrorCode.UserNotFoundError));
+
+        log.info("가져온 유저 정보:{}", minecraftUser.getPlayerName());
+
+        return UserInfoInquiryDto.of(user, minecraftUser);
+    }
+
+
+}

--- a/src/main/java/org/turtle/minecraft_service/swagger/ApiErrorCodeExample.java
+++ b/src/main/java/org/turtle/minecraft_service/swagger/ApiErrorCodeExample.java
@@ -1,0 +1,16 @@
+package org.turtle.minecraft_service.swagger;
+
+
+import org.turtle.minecraft_service.config.HttpErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+    String description() default "";
+    HttpErrorCode value();
+}

--- a/src/main/java/org/turtle/minecraft_service/swagger/ApiErrorCodeExamples.java
+++ b/src/main/java/org/turtle/minecraft_service/swagger/ApiErrorCodeExamples.java
@@ -1,0 +1,12 @@
+package org.turtle.minecraft_service.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+    ApiErrorCodeExample[] value();
+}

--- a/src/main/java/org/turtle/minecraft_service/swagger/ExampleHolder.java
+++ b/src/main/java/org/turtle/minecraft_service/swagger/ExampleHolder.java
@@ -1,0 +1,13 @@
+package org.turtle.minecraft_service.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=minecraft_service


### PR DESCRIPTION
작업과정은 다음과 같습니다.
1. application.yaml 파일 내 DB정보를 second-database로 추가 등록
2. 기존 MySQL DB와 추가된 마인크래프트 MySQL DB를 설정하기 위한 각각의 config 클래스 추가 및 그에 따른 domain, repository 디렉토리 구조 변동
3. 서비스단에서 @AuthenticationPrincipal에 담긴 User객체( 웹서비스 유저) 의 닉네임을 통해 마인크래프트 DB에 해당 닉네임을 가진 사용자 정보를 가져옴.

#6 