### PR TITLE
출석체크 로직 변경, 랭킹에서 관리자 명단 제외

### DIFF
--- a/src/main/java/org/turtle/minecraft_service/repository/secondary/MinecraftRepository.java
+++ b/src/main/java/org/turtle/minecraft_service/repository/secondary/MinecraftRepository.java
@@ -20,7 +20,8 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
            "WITH ranked_users AS (" +
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY progress DESC) as rank_num " +
-                   "    FROM user_detailed_info" +
+                   "    FROM user_detailed_info " +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -34,6 +35,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY money DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -48,6 +50,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    RANK() OVER (ORDER BY character_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
                    "    WHERE character_class = :jobName" +
+                   "    AND player_name NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -61,6 +64,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY fisher_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -75,6 +79,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY farming_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -89,6 +94,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY mining_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -103,6 +109,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY smithing_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +
@@ -117,6 +124,7 @@ public interface MinecraftRepository extends JpaRepository<MinecraftUser, Long> 
                    "    SELECT *, " +
                    "    RANK() OVER (ORDER BY cooking_level DESC) as rank_num " +
                    "    FROM user_detailed_info" +
+                   "    WHERE playerName NOT IN ('_appli_', 'Koo_pa_', '_YYH_', 'KSH_1348', 'kkOma_fan', 'uiu3111')" +
                    ") " +
                    "SELECT * " +
                    "FROM ranked_users " +

--- a/src/main/java/org/turtle/minecraft_service/service/common/CommonService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/common/CommonService.java
@@ -19,7 +19,7 @@ public class CommonService {
     private final MinecraftRepository minecraftRepository;
 
     public UserCountDto getCountOfUsers(){
-        List<String> gmPlayerNames = Arrays.asList("_appli_", "Koo_pa_", "_YYH_", "KSH_1348", "kkOma_fan");
+        List<String> gmPlayerNames = Arrays.asList("_appli_", "Koo_pa_", "_YYH_", "KSH_1348", "kkOma_fan", "uiu3111");
 
         int countOfUsers = minecraftRepository.findAllUsersWithoutGM(gmPlayerNames);
 

--- a/src/main/java/org/turtle/minecraft_service/service/redis/RedisService.java
+++ b/src/main/java/org/turtle/minecraft_service/service/redis/RedisService.java
@@ -151,12 +151,8 @@ public class RedisService {
     // 다음날 오전 6시까지 남은 시간(초) 계산
     private long getTimeOut() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime nextSixAM = now.with(LocalTime.of(6, 0));
-
-        // 현재 시각이 오전 6시 이후라면 다음날 오전 6시로 설정
-        if (now.getHour() >= 6) {
-            nextSixAM = nextSixAM.plusDays(1);
-        }
+        // 항상 다음 날 오전 6시로 설정
+        LocalDateTime nextSixAM = now.plusDays(1).with(LocalTime.of(6, 0));
 
         return ChronoUnit.SECONDS.between(now, nextSixAM);
     }


### PR DESCRIPTION
1. 서버 운영시간에 따른 출석체크 기록 저장 로직 변경을 진행하였습니다.
출석체크 기준으로 무조건 다음날 오전 6시에 초기화되게끔 하였습니다.

2. 랭킹 시스템에서 관리자 닉네임이 출력되는 것을 막았습니다.

